### PR TITLE
Фикс багов поиска и деталей вакансии

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
@@ -173,4 +173,9 @@ class SearchJobFragment : Fragment() {
         inputManager.hideSoftInputFromWindow(windowToken, 0)
 
     }
+
+    override fun onResume() {
+        super.onResume()
+        showView()
+    }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
@@ -239,7 +239,6 @@ class SearchJobFragment : Fragment() {
         super.onResume()
         showView()
     }
-
     private fun onScrollListener() {
         binding.recyclerViewSearch.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {

--- a/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
@@ -174,6 +174,7 @@ class SearchJobFragment : Fragment() {
 
     }
 
+    // Фикс бага
     override fun onResume() {
         super.onResume()
         showView()

--- a/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/ui/SearchJobFragment.kt
@@ -239,6 +239,7 @@ class SearchJobFragment : Fragment() {
         super.onResume()
         showView()
     }
+
     private fun onScrollListener() {
         binding.recyclerViewSearch.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {

--- a/app/src/main/res/layout/fragment_job_details.xml
+++ b/app/src/main/res/layout/fragment_job_details.xml
@@ -120,6 +120,7 @@
         android:layout_marginStart="@dimen/dp8"
         android:textColor="@color/Black"
         android:maxWidth="@dimen/dp250"
+        android:maxLines="2"
         app:layout_constraintBottom_toTopOf="@+id/jobCity"
         app:layout_constraintStart_toEndOf="@id/jobImage"
         app:layout_constraintTop_toTopOf="@id/jobImage"

--- a/app/src/main/res/layout/fragment_job_details.xml
+++ b/app/src/main/res/layout/fragment_job_details.xml
@@ -119,7 +119,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/dp8"
         android:textColor="@color/Black"
-        android:maxWidth="250dp"
+        android:maxWidth="@dimen/dp250"
         app:layout_constraintBottom_toTopOf="@+id/jobCity"
         app:layout_constraintStart_toEndOf="@id/jobImage"
         app:layout_constraintTop_toTopOf="@id/jobImage"

--- a/app/src/main/res/layout/fragment_job_details.xml
+++ b/app/src/main/res/layout/fragment_job_details.xml
@@ -104,10 +104,10 @@
 
     <ImageView
         android:id="@+id/jobImage"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/dp48"
+        android:layout_height="@dimen/dp48"
         android:layout_marginStart="@dimen/dp16"
-        android:background="@drawable/placeholder_logo"
+        tools:background="@drawable/placeholder_logo"
         app:layout_constraintBottom_toBottomOf="@id/jobCard"
         app:layout_constraintStart_toStartOf="@id/jobCard"
         app:layout_constraintTop_toTopOf="@id/jobCard" />
@@ -119,6 +119,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/dp8"
         android:textColor="@color/Black"
+        android:maxWidth="250dp"
         app:layout_constraintBottom_toTopOf="@+id/jobCity"
         app:layout_constraintStart_toEndOf="@id/jobImage"
         app:layout_constraintTop_toTopOf="@id/jobImage"

--- a/app/src/main/res/layout/fragment_search_job.xml
+++ b/app/src/main/res/layout/fragment_search_job.xml
@@ -58,12 +58,12 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/dp16"
-        android:popupTheme="@style/SuggestionsStyle"
         android:completionThreshold="@integer/suggestions_drop_down_completion_threshold"
         android:dropDownAnchor="@id/searchInputBackground"
         android:hint="@string/search_hint"
         android:inputType="textAutoComplete"
         android:minHeight="@dimen/search_input_min_height"
+        android:popupTheme="@style/SuggestionsStyle"
         android:textColorHint="@color/search_hint_gray_to_white"
         android:textCursorDrawable="@drawable/cursor_drawable"
         app:layout_constraintBottom_toBottomOf="@id/searchInputBackground"
@@ -97,7 +97,6 @@
         android:minHeight="0dp"
         android:textAllCaps="false"
         android:textColor="@color/White"
-        android:visibility="gone"
         app:cornerRadius="@dimen/dp12"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -128,6 +127,7 @@
 
         app:layout_constraintTop_toBottomOf="@id/searchInputBackground"
         tools:ignore="ContentDescription" />
+
     <include
         android:id="@+id/no_results_search_include"
         layout="@layout/no_result_search_item"
@@ -136,9 +136,8 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        tools:listitem="@layout/no_result_search_item"
         app:layout_constraintTop_toBottomOf="@id/searchInput"
-        />
+        tools:listitem="@layout/no_result_search_item" />
 
     <include
         android:id="@+id/server_error_include"
@@ -146,8 +145,8 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:visibility="gone"
-        tools:listitem="@layout/server_error_search_item"
-        app:layout_constraintTop_toBottomOf="@id/searchInputBackground"/>
+        app:layout_constraintTop_toBottomOf="@id/searchInputBackground"
+        tools:listitem="@layout/server_error_search_item" />
 
     <TextView
         android:id="@+id/searchPlaceholderText"
@@ -164,10 +163,11 @@
         android:id="@+id/searchJobsScrollView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_marginTop="@dimen/dp8"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchInputBackground">
+        app:layout_constraintTop_toBottomOf="@id/searchJobsCountButton">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/job_list_item.xml
+++ b/app/src/main/res/layout/job_list_item.xml
@@ -15,17 +15,19 @@
         android:contentDescription="@null"
         app:layout_constraintEnd_toStartOf="@id/jobTitle"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        />
 
     <TextView
         android:id="@+id/jobTitle"
         style="@style/MediumText.22size"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/dp12"
         android:ellipsize="end"
         android:maxLines="3"
         app:layout_constraintBottom_toTopOf="@id/jobEmployer"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/jobImage"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Android-разработчик, Москва" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -22,6 +22,7 @@
     <dimen name="dp80">80dp</dimen>
     <dimen name="dp328">328dp</dimen>
     <dimen name="dp224">224dp</dimen>
+    <dimen name="dp250">250dp</dimen>
 
     <dimen name="search_input_min_height">48dp</dimen>
     <dimen name="suggestions_drop_down_height">16dp</dimen>


### PR DESCRIPTION
Исправлены следующие баги: 
1) Отображалась картинка пустого поиска в поиске, когда уже был список вакансий
2) Список вакансий наезжал на синюю кнопку с числом вакансий
3) На экране деталей Компания выезжала за карточку (если слишком длинный текст)
4) Лого компании было не квадратным
5) Вместе с лого отображался плейсхолдер